### PR TITLE
Update styles and content in About templates

### DIFF
--- a/src/about.templ
+++ b/src/about.templ
@@ -5,48 +5,98 @@ templ AboutTempl() {
     @AboutChanours()
 }
 
+templ AboutChanours() {
+    <div class="person chanours">
+        <img class="image" src="https://avatars.githubusercontent.com/u/39670936"></img>
+        <div desc="desc">
+        </div>
+    </div>
+}
+
 templ AboutProuk() {
     <div class="person prouk">
         <img class="image" src="https://avatars.githubusercontent.com/u/21678081"></img>
         <div desc="desc">
             <h2>TAHON Valentin</h2>
             <p>
-                Go engineer working at <a class="no" href="https://worldline.com/" target="_blank">Worldline</a>.<br></br>
+                Go engineer working at <a class="no" href="https://worldline.com/" target="_blank">Worldline🔗</a>.<br></br>
                 Sometimes I sleep, seometimes I don't.
             </p>
         </div>
-        <div class="proficiency">
-            <h2>Proficiency ( including some frameworks )</h2>
-             <table>
-              <tr>
+        <div class="proficiencies">
+        <h2>Proficiencies ( including some frameworks )</h2>
+        <h3>Languages</h3>
+        <table>
+            <tr>
                 <td>Golang</td>
-                <td>85%</td>
-              </tr>
-              <tr>
+                <td>
+                    <div class="progressContainer">
+                        <div class="progress" style="width:85%">
+                        </div>
+                    </div>
+                </td>
+            </tr>
+            <tr>
                 <td>HTML / CSS / JS</td>
-                <td>85%</td>
-              </tr>
-              <tr>
+                <td>
+                    <div class="progressContainer">
+                        <div class="progress" style="width:85%">
+                        </div>
+                    </div>
+                </td>
+            </tr>
+            <tr>
                 <td>NodeJS</td>
-                <td>80%</td>
-              </tr>
-              <tr>
+                <td>
+                    <div class="progressContainer">
+                        <div class="progress" style="width:80%">
+                        </div>
+                    </div>
+                </td>
+            </tr>
+            <tr>
                 <td>SQL (PgSLQ / MySQL)</td>
-                <td>80%</td>
-              </tr>
-              <tr>
+                <td>
+                    <div class="progressContainer">
+                        <div class="progress" style="width:80%">
+                        </div>
+                    </div>
+                </td>
+            </tr>
+            <tr>
                 <td>PHP</td>
-                <td>75%</td>
-              </tr>
-            </table>
+                <td>
+                    <div class="progressContainer">
+                        <div class="progress" style="width:70%">
+                        </div>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td>Rust</td>
+                <td>
+                    <div class="progressContainer">
+                        <div class="progress" style="width:60%">
+                        </div>
+                    </div>
+                </td>
+            </tr>
+        </table>
         </div>
-    </div>
-}
-
-templ AboutChanours() {
-    <div class="person chanours">
-        <img class="image" src="https://avatars.githubusercontent.com/u/39670936"></img>
-        <div desc="desc">
+        <div class="experiences">
+            <h2>Experiences</h2>
+            <div>
+                <h3>Worldline</h3>
+            </div>
+            <div>
+                <h3>Umanis</h3>
+            </div>
+            <div>
+                <h3>Kimoce (Oslo)</h3>
+            </div>
+            <div>
+                <h3>Youdemus</h3>
+            </div>
         </div>
     </div>
 }

--- a/src/about_templ.go
+++ b/src/about_templ.go
@@ -38,7 +38,7 @@ func AboutTempl() templ.Component {
 	})
 }
 
-func AboutProuk() templ.Component {
+func AboutChanours() templ.Component {
 	return templ.ComponentFunc(func(ctx context.Context, templ_7745c5c3_W io.Writer) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templ_7745c5c3_W.(*bytes.Buffer)
 		if !templ_7745c5c3_IsBuffer {
@@ -51,7 +51,7 @@ func AboutProuk() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"person prouk\"><img class=\"image\" src=\"https://avatars.githubusercontent.com/u/21678081\"><div desc=\"desc\"><h2>TAHON Valentin</h2><p>Go engineer working at <a class=\"no\" href=\"https://worldline.com/\" target=\"_blank\">Worldline</a>.<br>Sometimes I sleep, seometimes I don't.\r</p></div><div class=\"proficiency\"><h2>Proficiency ( including some frameworks )</h2><table><tr><td>Golang</td><td>85%</td></tr><tr><td>HTML / CSS / JS</td><td>85%</td></tr><tr><td>NodeJS</td><td>80%</td></tr><tr><td>SQL (PgSLQ / MySQL)</td><td>80%</td></tr><tr><td>PHP</td><td>75%</td></tr></table></div></div>")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"person chanours\"><img class=\"image\" src=\"https://avatars.githubusercontent.com/u/39670936\"><div desc=\"desc\"></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -62,7 +62,7 @@ func AboutProuk() templ.Component {
 	})
 }
 
-func AboutChanours() templ.Component {
+func AboutProuk() templ.Component {
 	return templ.ComponentFunc(func(ctx context.Context, templ_7745c5c3_W io.Writer) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templ_7745c5c3_W.(*bytes.Buffer)
 		if !templ_7745c5c3_IsBuffer {
@@ -75,7 +75,7 @@ func AboutChanours() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"person chanours\"><img class=\"image\" src=\"https://avatars.githubusercontent.com/u/39670936\"><div desc=\"desc\"></div></div>")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"person prouk\"><img class=\"image\" src=\"https://avatars.githubusercontent.com/u/21678081\"><div desc=\"desc\"><h2>TAHON Valentin</h2><p>Go engineer working at <a class=\"no\" href=\"https://worldline.com/\" target=\"_blank\">Worldline🔗</a>.<br>Sometimes I sleep, seometimes I don't.\r</p></div><div class=\"proficiencies\"><h2>Proficiencies ( including some frameworks )</h2><h3>Languages</h3><table><tr><td>Golang</td><td><div class=\"progressContainer\"><div class=\"progress\" style=\"width:85%\"></div></div></td></tr><tr><td>HTML / CSS / JS</td><td><div class=\"progressContainer\"><div class=\"progress\" style=\"width:85%\"></div></div></td></tr><tr><td>NodeJS</td><td><div class=\"progressContainer\"><div class=\"progress\" style=\"width:80%\"></div></div></td></tr><tr><td>SQL (PgSLQ / MySQL)</td><td><div class=\"progressContainer\"><div class=\"progress\" style=\"width:80%\"></div></div></td></tr><tr><td>PHP</td><td><div class=\"progressContainer\"><div class=\"progress\" style=\"width:70%\"></div></div></td></tr><tr><td>Rust</td><td><div class=\"progressContainer\"><div class=\"progress\" style=\"width:60%\"></div></div></td></tr></table></div><div class=\"experiences\"><h2>Experiences</h2><div><h3>Worldline</h3></div><div><h3>Umanis</h3></div><div><h3>Kimoce (Oslo)</h3></div><div><h3>Youdemus</h3></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/stylesheets/main.css
+++ b/web/stylesheets/main.css
@@ -62,3 +62,33 @@ footer {
     margin: auto;
     border-radius: 10px;
 }
+
+.person .proficiencies table {
+    width: 80%;
+    padding: 20px;
+    margin: auto;
+    border-radius: 10px;
+    box-shadow: 0 0 15px 0 var(--box-shadow-color);
+}
+
+.person .proficiencies table td{
+    height: 1.75em;
+    width: 50%;
+}
+
+.progressContainer {
+    background-color: #868686;
+    border-radius: 5px;
+    width: 100%;
+    height: 1em;
+    overflow: hidden;
+}
+
+.progress {
+    background-color: #39bfd2;
+    height: 1em;
+}
+
+.person .experiences > div {
+
+}


### PR DESCRIPTION
This commit revises the main.css and the About templates in about_templ.go and about.templ. It extends the CSS for .person .proficiencies table, td and .progressContainer plus .progress classes. Meanwhile, the About templates got updated, specifically swapping the details of two persons and changing the way their proficiencies are displayed - now using a progress bar instead of percentage numbers. This improves the site's visual appeal and adds information clarity.